### PR TITLE
Force UserAgent to bypass Google browser deprecation

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -90,6 +90,7 @@ class AuthController {
         '&response_type=code' +
         '&redirect_uri=' + process.env.GOOGLE_REDIRECT_URI +
         '&state=' + channel // state parameter will be passed to the redirect_uri
+        , {userAgent: 'Chrome'}
       );
 
       /**

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -89,8 +89,10 @@ class AuthController {
         '&scope=email profile' +
         '&response_type=code' +
         '&redirect_uri=' + process.env.GOOGLE_REDIRECT_URI +
-        '&state=' + channel // state parameter will be passed to the redirect_uri
-        , {userAgent: 'Chrome'}
+        '&state=' + channel, // state parameter will be passed to the redirect_uri
+        {
+          userAgent: 'Chrome' // bypass Google check of outdated browser
+        }
       );
 
       /**


### PR DESCRIPTION
Google think that Electron is outdated. We bypass this check.

**Related issue description**
https://support.google.com/accounts/thread/22873505?hl=en
https://github.com/firebase/firebase-js-sdk/issues/2478
etc